### PR TITLE
Use NVARCHAR for string and text type

### DIFF
--- a/mssql.go
+++ b/mssql.go
@@ -123,10 +123,8 @@ func mapColumn(column *rel.Column) (string, int, int) {
 		typ = "BIT"
 	case rel.Int:
 		typ = "INT"
-		// m = column.Limit
 	case rel.BigInt:
 		typ = "BIGINT"
-		// m = column.Limit
 	case rel.Float:
 		typ = "FLOAT"
 		m = column.Precision
@@ -135,14 +133,15 @@ func mapColumn(column *rel.Column) (string, int, int) {
 		m = column.Precision
 		n = column.Scale
 	case rel.String:
-		typ = "VARCHAR"
+		typ = "NVARCHAR"
 		m = column.Limit
 		if m == 0 {
 			m = 255
+		} else if m > 4000 {
+			m = 4000
 		}
 	case rel.Text:
-		typ = "TEXT"
-		m = column.Limit
+		typ = "NVARCHAR(MAX)"
 	case rel.Date:
 		typ = "DATE"
 		timeLayout = "2006-01-02"


### PR DESCRIPTION
- GO string (Unicode) best matches to NVARCHAR instead of VARCHAR. That will support the full Unicode set. (https://github.com/go-rel/mssql/issues/6)
- The "text" type is deprecated in SQL Server and will be removed in a future version (https://github.com/go-rel/mssql/issues/7)